### PR TITLE
host metainfo in flathub repo

### DIFF
--- a/rocks.koreader.KOReader.metainfo.xml
+++ b/rocks.koreader.KOReader.metainfo.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+  <id>rocks.koreader.KOReader</id>
+  <launchable type="desktop-id">rocks.koreader.KOReader.desktop</launchable>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>AGPL-3.0-only</project_license>
+  <name>KOReader</name>
+  <summary>A document viewer for DjVu, PDF, EPUB and more</summary>
+  <description>
+    <p>
+      KOReader is a document viewer for E Ink devices. It supports PDF, DjVu, XPS, CBT, CBZ, FB2,
+      PDB, TXT, HTML, RTF, CHM, EPUB, DOC, MOBI, and ZIP files.
+    </p>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image>
+        https://github.com/koreader/koreader-artwork/raw/master/koreader-menu.png</image>
+    </screenshot>
+    <screenshot>
+      <image>
+        https://github.com/koreader/koreader-artwork/raw/master/koreader-footnotes.png</image>
+    </screenshot>
+    <screenshot>
+      <image>
+        https://github.com/koreader/koreader-artwork/raw/master/koreader-dictionary.png</image>
+    </screenshot>
+  </screenshots>
+  <url type="homepage">https://koreader.rocks/</url>
+  <url type="bugtracker">https://github.com/koreader/koreader/issues</url>
+  <url type="faq">https://github.com/koreader/koreader/wiki</url>
+  <url type="translate">https://github.com/koreader/koreader#translation</url>
+  <url type="vcs-browser">https://github.com/koreader/koreader</url>
+  <url type="contribute">https://koreader.rocks/doc/</url>
+  <categories>
+    <category>Viewer</category>
+    <category>Literature</category>
+  </categories>
+  <content_rating type="oars-1.1" />
+  <releases>
+    <release version="2023.01" date="2023-01-31" />
+  </releases>
+</component>

--- a/rocks.koreader.KOReader.yml
+++ b/rocks.koreader.KOReader.yml
@@ -24,7 +24,7 @@ modules:
     buildsystem: simple
     build-commands:
       - install -Dm755 koreader.sh ${FLATPAK_DEST}/bin/koreader
-      - install -Dm644 koreader.appdata.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
+      - install -Dm644 rocks.koreader.KOReader.metainfo.xml ${FLATPAK_DEST}/share/metainfo/${FLATPAK_ID}.metainfo.xml
 
       - ar x koreader.deb
       - tar xf data.tar.xz
@@ -76,13 +76,7 @@ modules:
             exec '/app/koreader/reader.lua' "$@"
 
       - type: file
-        url: https://raw.githubusercontent.com/koreader/koreader/master/platform/appimage/koreader.appdata.xml
-        sha256: c4b7ee8cd875f48b1b469123e9eded9e23e824754f0cb60019824ed6de3bad55
-        dest-filename: koreader.appdata.xml
-        x-checker-data:
-          type: rotating-url
-          url: https://github.com/koreader/koreader/raw/master/platform/appimage/koreader.appdata.xml
-          pattern: https://github.com/koreader/koreader/raw/master/platform/appimage/koreader.appdata.xml
+        path: rocks.koreader.KOReader.metainfo.xml
 
       - type: file
         url: https://raw.githubusercontent.com/koreader/koreader/master/resources/koreader.svg


### PR DESCRIPTION
the upstream doesn't update the <releases> tag, which is required on flathub