### PR TITLE
improve appstream metadata

### DIFF
--- a/rocks.koreader.KOReader.metainfo.xml
+++ b/rocks.koreader.KOReader.metainfo.xml
@@ -5,6 +5,7 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>AGPL-3.0-only</project_license>
   <name>KOReader</name>
+  <developer_name>KOReader Community</developer_name>
   <summary>A document viewer for DjVu, PDF, EPUB and more</summary>
   <description>
     <p>
@@ -29,7 +30,7 @@
   <url type="homepage">https://koreader.rocks/</url>
   <url type="bugtracker">https://github.com/koreader/koreader/issues</url>
   <url type="faq">https://github.com/koreader/koreader/wiki</url>
-  <url type="translate">https://github.com/koreader/koreader#translation</url>
+  <url type="translate">https://hosted.weblate.org/engage/koreader/</url>
   <url type="vcs-browser">https://github.com/koreader/koreader</url>
   <url type="contribute">https://koreader.rocks/doc/</url>
   <categories>


### PR DESCRIPTION
- add developer name (can be shown on flathub.org)
- set `Translate` link to the Weblate page rather than the ambiguous `README.md`