### PR TITLE
refactor: use only the commit to refer to koreaders-fonts

### DIFF
--- a/rocks.koreader.KOReader.yml
+++ b/rocks.koreader.KOReader.yml
@@ -104,6 +104,5 @@ modules:
 
       - type: git
         url: https://github.com/koreader/koreader-fonts
-        branch: master
         commit: 046976988aa33639d60d6ffd25c7a0ff50b72ac0
         dest: fonts


### PR DESCRIPTION
Fixes https://github.com/flathub/rocks.koreader.KOReader/issues/29