### PR TITLE
bump sdk

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "shared-modules"]
-	path = shared-modules
-	url = https://github.com/flathub/shared-modules.git

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # KOReader (rocks.koreader.KOReader)
 
+This repo builds KOReader flathub packages based on the latest released upstream binaries,
+for x86_64 and aarch64.
+
 ## Permissions rationale
 
 1. Read and manage documents:

--- a/rocks.koreader.KOReader.yml
+++ b/rocks.koreader.KOReader.yml
@@ -1,14 +1,14 @@
 app-id: rocks.koreader.KOReader
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
-base-version: '23.08'
 command: koreader
 separate-locales: false
 
 finish-args:
   # For game controller access
   - --device=all
+
   - --share=ipc
   - --share=network
   - --socket=wayland
@@ -19,8 +19,6 @@ finish-args:
   - --env=PATH=/app/bin:/usr/bin:/run/host/usr/bin:/run/host/bin
 
 modules:
-  - shared-modules/SDL2/SDL2-with-libdecor.json
-
   - name: koreader
     buildsystem: simple
     build-commands:


### PR DESCRIPTION
- FreeDesktop 24.08
- remove shared modules (sdl2 + libdecor is part of the runtime as of 23.08)

related to https://github.com/koreader/koreader-base/pull/1946