### PR TITLE
Add host binaries to PATH

### DIFF
--- a/rocks.koreader.KOReader.yml
+++ b/rocks.koreader.KOReader.yml
@@ -16,6 +16,7 @@ finish-args:
   - --filesystem=host
   - --filesystem=xdg-run/gvfs
   - --env=LD_LIBRARY_PATH=/app/lib
+  - --env=PATH=/app/bin:/usr/bin:/run/host/usr/bin:/run/host/bin
 
 modules:
   - shared-modules/SDL2/SDL2-with-libdecor.json


### PR DESCRIPTION
On startup, the app tries to check its connection by calling `ping` on the host OS, but the Freedesktop SDK does not come with `ping`, which leads to some networking features being disabled or malfunction. Adding the host's `/bin` and `/usr/bin` to the `PATH` should fix the issue.

Will close koreader/koreader#12571