### PR TITLE
stop messing with LD_LIBRARY_PATH

### DIFF
--- a/rocks.koreader.KOReader.yml
+++ b/rocks.koreader.KOReader.yml
@@ -15,7 +15,6 @@ finish-args:
   - --socket=fallback-x11
   - --filesystem=host
   - --filesystem=xdg-run/gvfs
-  - --env=LD_LIBRARY_PATH=/app/lib
   - --env=PATH=/app/bin:/usr/bin:/run/host/usr/bin:/run/host/bin
 
 modules:


### PR DESCRIPTION
We should not need it with our RPATH entries and our `ffi.loadlib` helper.